### PR TITLE
Remove unrequired comment after tuple refactor

### DIFF
--- a/src/HttpClientInterception/HttpClientInterceptorOptions.cs
+++ b/src/HttpClientInterception/HttpClientInterceptorOptions.cs
@@ -353,7 +353,7 @@ namespace JustEat.HttpClientInterception
             {
                 return null;
             }
-            
+
             if (response!.OnIntercepted != null && !await response.OnIntercepted(request, cancellationToken).ConfigureAwait(false))
             {
                 return null;


### PR DESCRIPTION
I was reviewing the code in relation to #369 and noticed after the tuple refactor a comment relating to the previous tuple usage which didn't make sense anymore. 