### PR TITLE
PR automation

### DIFF
--- a/.github/workflows/approve-and-merge.yml
+++ b/.github/workflows/approve-and-merge.yml
@@ -1,0 +1,160 @@
+name: approve-and-merge
+
+on:
+  pull_request:
+    branches: [ main ]
+
+env:
+  REVIEWER_LOGIN: ${{ vars.REVIEWER_USER_NAME }}
+
+permissions:
+  contents: read
+
+jobs:
+  review-pull-request:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == vars.UPDATER_COMMIT_USER_NAME }}
+
+    steps:
+
+    - name: Generate GitHub application token
+      id: generate-application-token
+      uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db # v2.1.0
+      with:
+        application_id: ${{ secrets.REVIEWER_APPLICATION_ID }}
+        application_private_key: ${{ secrets.REVIEWER_APPLICATION_PRIVATE_KEY }}
+        permissions: "contents:write, pull_requests:write"
+
+    - name: Install powershell-yaml
+      shell: pwsh
+      run: Install-Module -Name powershell-yaml -Force -MaximumVersion "0.4.7"
+
+    - name: Check which dependencies were updated
+      id: check-dependencies
+      env:
+        # This list of trusted package prefixes needs to stay in sync with include-nuget-packages in the update-dotnet-sdk workflow.
+        INCLUDE_NUGET_PACKAGES: "Microsoft.AspNetCore.,Microsoft.NET.Test.Sdk"
+        GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+      shell: pwsh
+      run: |
+        # Replicate the logic in the dependabot/fetch-metadata action.
+        # See https://github.com/dependabot/fetch-metadata/blob/aea2135c95039f05c64436f1d14638c300e10b2b/src/dependabot/update_metadata.ts#L29-L68.
+        # Query the GitHub API to get the commits in the pull request.
+        $commits = gh api `
+          /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits `
+          --jq '.[] | { author: .author.login, message: .commit.message }' | ConvertFrom-Json
+
+        # We should only approve pull requests that only contain commits from
+        # the GitHub user we expected and only commits that contain the metadata
+        # we need to determine what dependencies were updated by the other workflow.
+        $expectedUser = "${{ vars.UPDATER_COMMIT_USER_NAME }}"
+        $onlyDependencyUpdates = $True
+        $onlyChangesFromUser = $True
+
+        $dependencies = @()
+
+        foreach ($commit in $commits) {
+          if ($commit.Author -ne $expectedUser) {
+            # Some other commit is in the pull request
+            $onlyChangesFromUser = $False
+          }
+          # Extract the YAML metadata block from the commit message.
+          $match = [Regex]::Match($commit.Message, '(?m)^-{3}\s(?<dependencies>[\S|\s]*?)\s^\.{3}$')
+          if ($match.Success -eq $True) {
+            # Extract the names and update type from each dependency.
+            $metadata = ($match.Value | ConvertFrom-Yaml -Ordered)
+            $updates = $metadata["updated-dependencies"]
+            if ($updates) {
+              foreach ($update in $updates) {
+                $dependencies += @{
+                  Name = $update['dependency-name'];
+                  Type = $update['update-type'];
+                }
+              }
+            }
+          }
+          else {
+            # The pull request contains a commit that we didn't expect as the metadata is missing.
+            $onlyDependencyUpdates = $False
+          }
+        }
+
+        # Did we find at least one dependency?
+        $isPatch = $dependencies.Length -gt 0
+        $onlyTrusted = $dependencies.Length -gt 0
+        $trustedPackages = $env:INCLUDE_NUGET_PACKAGES.Split(',')
+
+        foreach ($dependency in $dependencies) {
+          $isPatch = $isPatch -And $dependency.Type -eq "version-update:semver-patch"
+          $onlyTrusted = $onlyTrusted -And
+            (
+              ($dependency.Name -eq "Microsoft.NET.Sdk") -Or
+              (($trustedPackages | Where-Object { $dependency.Name.StartsWith($_) }).Count -gt 0)
+            )
+        }
+
+        # We only trust the pull request to approve and auto-merge it
+        # if it only contains commits which change the .NET SDK and
+        # Microsoft-published NuGet packages that were made by the GitHub
+        # login we expect to make those changes in the other workflow.
+        $isTrusted = (($onlyTrusted -And $isPatch) -And $onlyChangesFromUser) -And $onlyDependencyUpdates
+        "is-trusted-update=$isTrusted" >> $env:GITHUB_OUTPUT
+
+    - name: Checkout code
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      # As long as it's not already approved, approve the pull request and enable auto-merge.
+      # Our CI tests coupled with required statuses should ensure that the changes compile
+      # and that the application is still functional after the update; any bug that might be
+      # introduced by the update should be caught by the tests. If that happens, the build
+      # workflow will fail and the preconditions for the auto-merge to happen won't be met.
+    - name: Approve pull request and enable auto-merge
+      if: ${{ steps.check-dependencies.outputs.is-trusted-update == 'true' }}
+      env:
+        GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      shell: pwsh
+      run: |
+        $approvals = gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews | ConvertFrom-Json
+        $approvals = $approvals | Where-Object { $_.user.login -eq $env:REVIEWER_LOGIN }
+        $approvals = $approvals | Where-Object { $_.state -eq "APPROVED" }
+
+        if ($approvals.Length -eq 0) {
+          gh pr checkout "$env:PR_URL"
+          gh pr review --approve "$env:PR_URL"
+          gh pr merge --auto --squash "$env:PR_URL"
+        }
+        else {
+          Write-Host "PR already approved.";
+        }
+
+    # If something was present in the pull request that isn't expected, then disable
+    # auto-merge so that a human is required to look at the pull request and make a
+    # decision to merge it or not. This is to prevent the pull request from being merged
+    # automatically if there's an unexpected change introduced. Any existing review
+    # approvals that were made by the bot are also dismissed so human approval is required.
+    - name: Disable auto-merge and dismiss approvals
+      if: ${{ steps.check-dependencies.outputs.is-trusted-update != 'true' }}
+      env:
+        GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      shell: pwsh
+      run: |
+        $approvals = gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews | ConvertFrom-Json
+        $approvals = $approvals | Where-Object { $_.user.login -eq $env:REVIEWER_LOGIN }
+        $approvals = $approvals | Where-Object { $_.state -eq "APPROVED" }
+
+        if ($approvals.Length -gt 0) {
+          gh pr checkout "$env:PR_URL"
+          gh pr merge --disable-auto "$env:PR_URL"
+          foreach ($approval in $approvals) {
+            gh api `
+              --method PUT `
+              /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/$($approval.id)/dismissals `
+              -f message='Cannot approve as other changes have been introduced.' `
+              -f event='DISMISS'
+          }
+        }
+        else {
+          Write-Host "PR not already approved.";
+        }

--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -1,0 +1,48 @@
+name: dependabot-approve
+
+on: pull_request_target
+
+permissions:
+  contents: read
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+
+    steps:
+
+      - name: Get dependabot metadata
+        uses: dependabot/fetch-metadata@efb5c8deb113433243b6b08de1aa879d5aa01cf7 # v1.4.0
+        id: dependabot-metadata
+
+      - name: Generate GitHub application token
+        id: generate-application-token
+        uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db # v2.1.0
+        with:
+          application_id: ${{ secrets.REVIEWER_APPLICATION_ID }}
+          application_private_key: ${{ secrets.REVIEWER_APPLICATION_PRIVATE_KEY }}
+          permissions: "contents:write, pull_requests:write"
+
+      - name: Checkout code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Approve pull request and enable auto-merge
+        shell: bash
+        if: |
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/cache') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/checkout') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/dependency-review-action') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/download-artifact') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/setup-dotnet') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'actions/upload-artifact') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'dependabot/fetch-metadata') ||
+          contains(steps.dependabot-metadata.outputs.dependency-names, 'github/codeql-action')
+        env:
+          GH_TOKEN: ${{ steps.generate-application-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr checkout "$PR_URL"
+          if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ];
+          then gh pr review --approve "$PR_URL" && gh pr merge --auto --squash "$PR_URL"
+          fi

--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -1,13 +1,7 @@
 name: update-dotnet-sdk
 
-env:
-  GIT_COMMIT_USER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-  GIT_COMMIT_USER_NAME: github-actions[bot]
-  TERM: xterm
-
 on:
   schedule:
-    - cron:  '30 09 * * MON-FRI'
     - cron:  '00 19 * * TUE'
   workflow_dispatch:
 
@@ -15,127 +9,13 @@ permissions:
   contents: read
 
 jobs:
-  update-dotnet-sdk:
-    name: Update .NET SDK
-    runs-on: ubuntu-latest
-    if: ${{ github.event.repository.fork == false }}
-
-    permissions:
-      contents: write
-      pull-requests: write
-
-    steps:
-
-    - name: Checkout code
-      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Update .NET SDK
-      id: update-dotnet-sdk
-      uses: martincostello/update-dotnet-sdk@a9c7965f8619036551db9aaa4d6ff5e186ccd700 # v2.1.2
-      with:
-        labels: "dependencies,.NET"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        user-email: ${{ env.GIT_COMMIT_USER_EMAIL }}
-        user-name: ${{ env.GIT_COMMIT_USER_NAME }}
-
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@607fce577a46308457984d59e4954e075820f10a # v3.0.3
-      if : ${{ steps.update-dotnet-sdk.outputs.sdk-updated == 'true' }}
-
-    - name: Setup NuGet cache
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-      if : ${{ steps.update-dotnet-sdk.outputs.sdk-updated == 'true' }}
-      with:
-        path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
-        restore-keys: ${{ runner.os }}-nuget-
-
-    - name: Update NuGet packages
-      if : ${{ steps.update-dotnet-sdk.outputs.sdk-updated == 'true' }}
-      shell: pwsh
-      env:
-        DOTNET_CLI_TELEMETRY_OPTOUT: true
-        DOTNET_NOLOGO: true
-        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-        DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
-        NUGET_XMLDOC_MODE: skip
-      run: |
-        $ErrorActionPreference = "Stop"
-
-        dotnet tool install --global dotnet-outdated-tool
-
-        $tempPath = [System.IO.Path]::GetTempPath()
-        $updatesPath = (Join-Path $tempPath "dotnet-outdated.json")
-
-        Write-Host "Checking for .NET NuGet package(s) to update..."
-
-        dotnet outdated `
-          --upgrade `
-          --version-lock Major `
-          --output $updatesPath `
-          --include "Microsoft.AspNetCore." `
-          --include "Microsoft.EntityFrameworkCore." `
-          --include "Microsoft.Extensions." `
-          --include "Microsoft.NET.Test.Sdk"
-
-        $dependencies = @()
-
-        if (Test-Path $updatesPath) {
-          $dependencies = `
-            Get-Content -Path $updatesPath | `
-            ConvertFrom-Json | `
-            Select-Object -ExpandProperty projects | `
-            Select-Object -ExpandProperty TargetFrameworks | `
-            Select-Object -ExpandProperty Dependencies | `
-            Sort-Object -Property Name -Unique
-        }
-
-        if ($dependencies.Count -gt 0) {
-          Write-Host "Found $($dependencies.Count) .NET NuGet package(s) to update." -ForegroundColor Green
-
-          $commitMessageLines = @()
-
-          if ($dependencies.Count -eq 1) {
-            $commitMessageLines += "Bump $($dependencies[0].Name) from $($dependencies[0].ResolvedVersion) to $($dependencies[0].LatestVersion)"
-            $commitMessageLines += ""
-            $commitMessageLines += "Bumps $($dependencies[0].Name) from $($dependencies[0].ResolvedVersion) to $($dependencies[0].LatestVersion)."
-          } else {
-            $commitMessageLines += "Bump .NET NuGet packages"
-            $commitMessageLines += ""
-            $commitMessageLines += "Bumps .NET dependencies to their latest versions for the .NET ${{ steps.update-dotnet-sdk.outputs.sdk-version }} SDK."
-            $commitMessageLines += ""
-            foreach ($dependency in $dependencies) {
-              $commitMessageLines += "Bumps $($dependency.Name) from $($dependency.ResolvedVersion) to $($dependency.LatestVersion)."
-            }
-          }
-
-          $commitMessageLines += ""
-          $commitMessageLines += "---"
-          $commitMessageLines += "updated-dependencies:"
-
-          foreach ($dependency in $dependencies) {
-            $commitMessageLines += "- dependency-name: $($dependency.Name)"
-            $commitMessageLines += "  dependency-type: direct:production"
-            $commitMessageLines += "  update-type: version-update:semver-$($dependency.UpgradeSeverity.ToLowerInvariant())"
-          }
-
-          $commitMessageLines += "..."
-          $commitMessageLines += ""
-          $commitMessageLines += ""
-
-          $commitMessage = $commitMessageLines -join "`n"
-
-          git config user.email "${{ env.GIT_COMMIT_USER_EMAIL }}"
-          git config user.name "${{ env.GIT_COMMIT_USER_NAME }}"
-
-          git add .
-          git commit -m $commitMessage
-          git push
-
-          Write-Host "Pushed update to $($dependencies.Count) NuGet package(s)." -ForegroundColor Green
-        }
-        else {
-          Write-Host "There are no .NET NuGet packages to update." -ForegroundColor Green
-        }
+  update-sdk:
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@a9c7965f8619036551db9aaa4d6ff5e186ccd700 # v2.1.2
+    with:
+      include-nuget-packages: "Microsoft.AspNetCore.,Microsoft.EntityFrameworkCore.,Microsoft.Extensions.,Microsoft.NET.Test.Sdk"
+      labels: "dependencies,.NET"
+      user-email: ${{ vars.UPDATER_COMMIT_USER_EMAIL }}
+      user-name: ${{ vars.UPDATER_COMMIT_USER_NAME }}
+    secrets:
+      application-id: ${{ secrets.UPDATER_APPLICATION_ID }}
+      application-private-key: ${{ secrets.UPDATER_APPLICATION_PRIVATE_KEY }}


### PR DESCRIPTION
This PR makes a number of changes to GitHub actions to automate more of the repo maintenance.

The automation is based on [the approaches in this repository](https://github.com/martincostello/dotnet-patch-automation-sample/tree/main#readme) that has also been added to JustSaying in https://github.com/justeattakeaway/JustSaying/pull/1152.

Changes:

- Use [reusable workflow](https://github.com/martincostello/update-dotnet-sdk/tree/main#advanced-workflow) for updating the .NET SDK.
- Use a GitHub app to generate updates instead of `GITHUB_TOKEN` so that CI runs.
- Add a workflow to automatically approve and merge .NET SDK updates.
- Add a workflow to automatically approve and merge dependabot updates for GitHub-authored actions.
