### PR TITLE
Prepare for .NET 8

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Globalization" />
+    <Using Include="System.Net.Http" Condition=" '$(TargetFramework)' == 'net472' " />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
     <Using Include="Shouldly" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,12 +18,10 @@
     <PackageVersion Include="ReportGenerator" Version="5.1.22" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.435" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.Json" Version="4.7.2" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(AssemblyName)' == 'JustEat.HttpClientInterception' ">
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup Condition=" '$(AssemblyName)' == 'JustEat.HttpClientInterception' and '$(TargetFramework)' == 'net6.0' ">
     <PackageVersion Update="System.Text.Json" Version="6.0.0" />

--- a/samples/SampleApp.Tests/SampleApp.Tests.csproj
+++ b/samples/SampleApp.Tests/SampleApp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>$(NoWarn);CA1056;CA1062;CA1707;CA1711;CA2007;SA1600</NoWarn>
+    <NoWarn>$(NoWarn);CA1056;CA1062;CA1707;CA1711;CA1861;CA2007;SA1600</NoWarn>
     <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj
+++ b/tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Tests for JustEat.HttpClientInterception</Description>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>$(NoWarn);CA1303;CA1600;CA1707;CA1812;CA2000;CA2007;SA1600</NoWarn>
+    <NoWarn>$(NoWarn);CA1303;CA1600;CA1707;CA1812;CA1861;CA2000;CA2007;SA1600</NoWarn>
     <RootNamespace>JustEat.HttpClientInterception</RootNamespace>
     <Summary>Tests for JustEat.HttpClientInterception</Summary>
     <TargetFrameworks>net7.0</TargetFrameworks>


### PR DESCRIPTION
Cherry-pick changes from #558:

- Fix using for `System.Net.Http` for .NET Framework 4.7.2 caused by https://github.com/dotnet/sdk/pull/32630.
- Suppress `CA1861` in tests.
