### PR TITLE
Remove ExcludeByAttribute

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -59,7 +59,6 @@
     <CollectCoverage>true</CollectCoverage>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[*.Benchmarks]*,[*.Tests]*,[Refit]*,[SampleApp]*,[xunit.*]*</Exclude>
-    <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
     <Threshold>95</Threshold>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is set automatically, so we shouldn't need to specify it.
