### PR TITLE
Remove Scorecard token

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,7 +1,7 @@
 name: ossf-scorecard
 
 on:
-  branch_protection_rule:
+  #branch_protection_rule:
   push:
     branches: [ main ]
   schedule:
@@ -26,19 +26,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Get application token
-        id: get-application-token
-        uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db # v2.1.0
-        with:
-          application_id: ${{ vars.JET_GITHUB_APPLICATION_ID }}
-          application_private_key: ${{ secrets.JET_GITHUB_SECRET_KEY }}
-          organization: ${{ github.repository_owner }}
+      #- name: Get application token
+      #  id: get-application-token
+      #  uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db # v2.1.0
+      #  with:
+      #    application_id: ${{ vars.JET_GITHUB_APPLICATION_ID }}
+      #    application_private_key: ${{ secrets.JET_GITHUB_SECRET_KEY }}
+      #    organization: ${{ github.repository_owner }}
 
       - name: Run analysis
         uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           publish_results: true
-          repo_token: ${{ steps.get-application-token.outputs.token }}
+          #repo_token: ${{ steps.get-application-token.outputs.token }}
           results_file: results.sarif
           results_format: sarif
 


### PR DESCRIPTION
Turns out using a GitHub app [isn't currently supported](https://github.com/ossf/scorecard-action#workflow-restrictions), so until that can be used, comment out the new steps added by #664.
