### PR TITLE
Remove commented-out code

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,19 +26,10 @@ jobs:
         with:
           persist-credentials: false
 
-      #- name: Get application token
-      #  id: get-application-token
-      #  uses: peter-murray/workflow-application-token-action@8e1ba3bf1619726336414f1014e37f17fbadf1db # v2.1.0
-      #  with:
-      #    application_id: ${{ vars.JET_GITHUB_APPLICATION_ID }}
-      #    application_private_key: ${{ secrets.JET_GITHUB_SECRET_KEY }}
-      #    organization: ${{ github.repository_owner }}
-
       - name: Run analysis
         uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           publish_results: true
-          #repo_token: ${{ steps.get-application-token.outputs.token }}
           results_file: results.sarif
           results_format: sarif
 


### PR DESCRIPTION
Moving to repository rules means what I was trying to achieve by using a token works out-of-the-box, so this code can now just be tidied up.
