### PR TITLE
Support native AoT

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <VersionPrefix>4.1.0</VersionPrefix>
+    <VersionPrefix>4.2.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' AND '$(GITHUB_HEAD_REF)' != '' ">beta.$(GITHUB_RUN_NUMBER)</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>
@@ -67,6 +67,7 @@
     <CollectCoverage>true</CollectCoverage>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[*.Benchmarks]*,[*.Tests]*,[Refit]*,[SampleApp]*,[xunit.*]*</Exclude>
+    <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
     <Threshold>95</Threshold>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ using var client = options.CreateHttpClient();
 // The value of json will be: {"Id":1, "Link":"https://www.just-eat.co.uk/privacy-policy"}
 string json = await client.GetStringAsync("https://public.je-apis.com/terms");
 ```
-<sup><a href='/tests/HttpClientInterception.Tests/Examples.cs#L44-L66' title='Snippet source file'>snippet source</a> | <a href='#snippet-minimal-example' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/tests/HttpClientInterception.Tests/Examples.cs#L46-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-minimal-example' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 `HttpRequestInterceptionBuilder` objects are mutable, so properties can be freely changed once a particular setup has been registered with an instance of `HttpClientInterceptorOptions` as the state is captured at the point of registration. This allows multiple responses and paths to be configured from a single `HttpRequestInterceptionBuilder` instance where multiple registrations against a common hostname.
@@ -143,7 +143,7 @@ var client = options.CreateHttpClient();
 await Assert.ThrowsAsync<HttpRequestException>(
     () => client.GetStringAsync("http://public.je-apis.com"));
 ```
-<sup><a href='/tests/HttpClientInterception.Tests/Examples.cs#L23-L38' title='Snippet source file'>snippet source</a> | <a href='#snippet-fault-injection' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/tests/HttpClientInterception.Tests/Examples.cs#L25-L40' title='Snippet source file'>snippet source</a> | <a href='#snippet-fault-injection' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 #### Registering Request Interception When Using IHttpClientFactory

--- a/README.md
+++ b/README.md
@@ -242,24 +242,29 @@ Further examples of using the library can be found by following the links below:
 
 ### Benchmarks
 
-Generated with the [Benchmarks project](https://github.com/justeattakeaway/httpclient-interception/blob/main/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs "JustEat.HttpClientInterception benchmark code") using [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet "BenchmarkDotNet on GitHub.com") using commit [c31abf3](https://github.com/justeattakeaway/httpclient-interception/commit/f38ae38d9f0abd50f380d699c281d76e1a1513c9 "Benchmark commit") on 15/11/2022.
-
-``` ini
-
-BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22000.1098/21H2)
-Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
-.NET SDK=7.0.100
-  [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
-
+Generated with the [Benchmarks project](https://github.com/justeattakeaway/httpclient-interception/blob/main/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs "JustEat.HttpClientInterception benchmark code") using [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet "BenchmarkDotNet on GitHub.com") using commit [ef93cb5](https://github.com/justeattakeaway/httpclient-interception/commit/ef93cb5a54b518fe488de63be962ddf15644ef42 "Benchmark commit") on 04/02/2024.
 
 ```
-|           Method |      Mean |     Error |    StdDev |   Gen0 | Allocated |
-|----------------- |----------:|----------:|----------:|-------:|----------:|
-|         [`GetBytes`](https://github.com/justeattakeaway/httpclient-interception/blob/f38ae38d9f0abd50f380d699c281d76e1a1513c9/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs#L76-L80) |  3.102 μs | 0.0780 μs | 0.2264 μs | 0.3128 |    2648 B |
-|          [`GetHtml`](https://github.com/justeattakeaway/httpclient-interception/blob/f38ae38d9f0abd50f380d699c281d76e1a1513c9/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs#L82-L86) |  3.675 μs | 0.0735 μs | 0.2143 μs | 0.3700 |    3104 B |
-|          [`GetJson`](https://github.com/justeattakeaway/httpclient-interception/blob/f38ae38d9f0abd50f380d699c281d76e1a1513c9/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs#L88-L93) |  5.175 μs | 0.1223 μs | 0.3470 μs | 0.3433 |    2904 B |
-|        [`GetStream`](https://github.com/justeattakeaway/httpclient-interception/blob/f38ae38d9f0abd50f380d699c281d76e1a1513c9/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs#L101-L107) | 36.359 μs | 0.7168 μs | 1.3981 μs | 0.3662 |    3312 B |
+
+BenchmarkDotNet v0.13.12, Windows 11 (10.0.22621.3007/22H2/2022Update/SunValley2)
+12th Gen Intel Core i7-1270P, 1 CPU, 16 logical and 12 physical cores
+.NET SDK 8.0.101
+  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
+  Job-IMNGZO : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
+
+Arguments=/p:UseArtifactsOutput=false  
+
+```
+| Method                       | Mean       | Error     | StdDev     | Median     | Gen0   | Allocated |
+|----------------------------- |-----------:|----------:|-----------:|-----------:|-------:|----------:|
+| GetBytes                     |   1.708 μs | 0.0338 μs |  0.0898 μs |   1.698 μs | 0.3223 |   2.98 KB |
+| GetHtml                      |   1.618 μs | 0.0324 μs |  0.0703 μs |   1.614 μs | 0.3319 |   3.06 KB |
+| GetJsonDocument              |   1.942 μs | 0.0381 μs |  0.0604 μs |   1.921 μs | 0.3071 |   2.84 KB |
+| GetJsonObject                |   2.460 μs | 0.0778 μs |  0.2195 μs |   2.413 μs | 0.3281 |   3.05 KB |
+| GetJsonObjectSourceGenerator |   2.345 μs | 0.0421 μs |  0.1102 μs |   2.311 μs | 0.3281 |   3.05 KB |
+| GetJsonObjectWithRefit       |   5.169 μs | 0.1025 μs |  0.2117 μs |   5.120 μs | 0.6714 |   6.35 KB |
+| GetStream                    | 209.607 μs | 4.5593 μs | 13.3717 μs | 210.077 μs | 0.2441 |   3.16 KB |
+
 
 ## Feedback
 

--- a/src/HttpClientInterception/Bundles/BundleFactory.cs
+++ b/src/HttpClientInterception/Bundles/BundleFactory.cs
@@ -10,14 +10,11 @@ namespace JustEat.HttpClientInterception.Bundles;
 /// </summary>
 internal static class BundleFactory
 {
+#if !NET6_0_OR_GREATER
     /// <summary>
     /// Gets the JSON serializer settings to use.
     /// </summary>
-    private static JsonSerializerOptions Settings { get; } =
-#if NET7_0_OR_GREATER
-        JsonSerializerOptions.Default;
-#else
-        new();
+    private static JsonSerializerOptions Settings { get; } = new();
 #endif
 
     /// <summary>
@@ -30,7 +27,11 @@ internal static class BundleFactory
     public static Bundle? Create(string path)
     {
         string json = File.ReadAllText(path);
+#if NET6_0_OR_GREATER
+        return JsonSerializer.Deserialize(json, BundleJsonSerializerContext.Default.Bundle);
+#else
         return JsonSerializer.Deserialize<Bundle>(json, Settings);
+#endif
     }
 
     /// <summary>
@@ -45,6 +46,11 @@ internal static class BundleFactory
     public static async ValueTask<Bundle?> CreateAsync(string path, CancellationToken cancellationToken)
     {
         using var stream = File.OpenRead(path);
+
+#if NET6_0_OR_GREATER
+        return await JsonSerializer.DeserializeAsync(stream, BundleJsonSerializerContext.Default.Bundle, cancellationToken).ConfigureAwait(false);
+#else
         return await JsonSerializer.DeserializeAsync<Bundle>(stream, Settings, cancellationToken).ConfigureAwait(false);
+#endif
     }
 }

--- a/src/HttpClientInterception/Bundles/BundleJsonSerializerContext.cs
+++ b/src/HttpClientInterception/Bundles/BundleJsonSerializerContext.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Just Eat, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+#if NET6_0_OR_GREATER
+using System.Text.Json.Serialization;
+
+namespace JustEat.HttpClientInterception.Bundles;
+
+[JsonSerializable(typeof(Bundle))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal sealed partial class BundleJsonSerializerContext : JsonSerializerContext
+{
+}
+#endif

--- a/src/HttpClientInterception/JustEat.HttpClientInterception.csproj
+++ b/src/HttpClientInterception/JustEat.HttpClientInterception.csproj
@@ -26,4 +26,11 @@
     <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Unshipped.txt" />
   </ItemGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
 </Project>

--- a/src/HttpClientInterception/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/HttpClientInterception/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static JustEat.HttpClientInterception.HttpClientInterceptorOptionsExtensions.RegisterGetFromJson<T>(this JustEat.HttpClientInterception.HttpClientInterceptorOptions! options, string! uriString, T content, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! jsonTypeInfo, System.Net.HttpStatusCode statusCode = System.Net.HttpStatusCode.OK) -> JustEat.HttpClientInterception.HttpClientInterceptorOptions!
+static JustEat.HttpClientInterception.HttpRequestInterceptionBuilderExtensions.WithJsonContent<T>(this JustEat.HttpClientInterception.HttpRequestInterceptionBuilder! builder, T content, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! jsonTypeInfo) -> JustEat.HttpClientInterception.HttpRequestInterceptionBuilder!

--- a/src/HttpClientInterception/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/src/HttpClientInterception/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static JustEat.HttpClientInterception.HttpClientInterceptorOptionsExtensions.RegisterGetFromJson<T>(this JustEat.HttpClientInterception.HttpClientInterceptorOptions! options, string! uriString, T content, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! jsonTypeInfo, System.Net.HttpStatusCode statusCode = System.Net.HttpStatusCode.OK) -> JustEat.HttpClientInterception.HttpClientInterceptorOptions!
+static JustEat.HttpClientInterception.HttpRequestInterceptionBuilderExtensions.WithJsonContent<T>(this JustEat.HttpClientInterception.HttpRequestInterceptionBuilder! builder, T content, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>! jsonTypeInfo) -> JustEat.HttpClientInterception.HttpRequestInterceptionBuilder!

--- a/src/HttpClientInterception/SystemTextJsonExtensions.cs
+++ b/src/HttpClientInterception/SystemTextJsonExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace JustEat.HttpClientInterception;
@@ -25,6 +26,12 @@ public static class SystemTextJsonExtensions
     /// <exception cref="ArgumentNullException">
     /// <paramref name="builder"/> or <paramref name="content"/> is <see langword="null"/>.
     /// </exception>
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(WarningMessages.SerializationUnreferencedCodeMessage)]
+#if NET7_0_OR_GREATER
+    [RequiresDynamicCode(WarningMessages.SerializationRequiresDynamicCodeMessage)]
+#endif
+#endif
     public static HttpRequestInterceptionBuilder WithSystemTextJsonContent(
         this HttpRequestInterceptionBuilder builder,
         object content,

--- a/src/HttpClientInterception/WarningMessages.cs
+++ b/src/HttpClientInterception/WarningMessages.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Just Eat, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace JustEat.HttpClientInterception;
+
+internal static class WarningMessages
+{
+    internal const string SerializationUnreferencedCodeMessage = "JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo, or make sure all of the required types are preserved.";
+    internal const string SerializationRequiresDynamicCodeMessage = "JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.";
+}

--- a/tests/HttpClientInterception.Benchmarks/CustomBenchmarkConfig.cs
+++ b/tests/HttpClientInterception.Benchmarks/CustomBenchmarkConfig.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Just Eat, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+
+namespace JustEat.HttpClientInterception;
+
+public class CustomBenchmarkConfig : ManualConfig
+{
+    public CustomBenchmarkConfig()
+        : base()
+    {
+        var job = Job.Default.WithArguments([new MsBuildArgument("/p:UseArtifactsOutput=false")]);
+
+        AddJob(job);
+        AddDiagnoser(MemoryDiagnoser.Default);
+        AddDiagnoser(new EventPipeProfiler(EventPipeProfile.CpuSampling));
+    }
+}

--- a/tests/HttpClientInterception.Benchmarks/GitHubJsonSerializerContext.cs
+++ b/tests/HttpClientInterception.Benchmarks/GitHubJsonSerializerContext.cs
@@ -1,18 +1,13 @@
 ﻿// Copyright (c) Just Eat, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+#if !NETFRAMEWORK
 using System.Text.Json.Serialization;
 
 namespace JustEat.HttpClientInterception;
 
-public sealed class Organization
+[JsonSerializable(typeof(Organization))]
+internal sealed partial class GitHubJsonSerializerContext : JsonSerializerContext
 {
-    [JsonPropertyName("login")]
-    public string Login { get; set; }
-
-    [JsonPropertyName("id")]
-    public long Id { get; set; }
-
-    [JsonPropertyName("url")]
-    public string Url { get; set; }
 }
+#endif

--- a/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs
+++ b/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs
@@ -3,13 +3,11 @@
 
 using System.Text.Json;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Diagnosers;
 using Refit;
 
 namespace JustEat.HttpClientInterception;
 
-[EventPipeProfiler(EventPipeProfile.CpuSampling)]
-[MemoryDiagnoser]
+[Config(typeof(CustomBenchmarkConfig))]
 public class InterceptionBenchmarks
 {
     private readonly HttpClientInterceptorOptions _options;

--- a/tests/HttpClientInterception.Benchmarks/Organization.cs
+++ b/tests/HttpClientInterception.Benchmarks/Organization.cs
@@ -7,7 +7,7 @@ public sealed class Organization
 {
     public string Login { get; set; }
 
-    public string Id { get; set; }
+    public long Id { get; set; }
 
     public string Url { get; set; }
 }

--- a/tests/HttpClientInterception.Tests/Bundles/BundleExtensionsTests.cs
+++ b/tests/HttpClientInterception.Tests/Bundles/BundleExtensionsTests.cs
@@ -11,24 +11,24 @@ namespace JustEat.HttpClientInterception.Bundles;
 
 public static class BundleExtensionsTests
 {
-    public static IEnumerable<object[]> BundleFiles
+    public static TheoryData<string> BundleFiles()
     {
-        get
+        var bundles = Directory.GetFiles("Bundles", "*.json");
+        var filePaths = new TheoryData<string>();
+
+        foreach (string path in bundles)
         {
-            var bundles = Directory.GetFiles("Bundles", "*.json");
-
-            foreach (string path in bundles)
+            if (path.Contains("invalid-", StringComparison.OrdinalIgnoreCase) ||
+                path.Contains("no", StringComparison.OrdinalIgnoreCase) ||
+                path.Contains("null-", StringComparison.OrdinalIgnoreCase))
             {
-                if (path.Contains("invalid-", StringComparison.OrdinalIgnoreCase) ||
-                    path.Contains("no", StringComparison.OrdinalIgnoreCase) ||
-                    path.Contains("null-", StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                yield return new object[] { path };
+                continue;
             }
+
+            filePaths.Add(path);
         }
+
+        return filePaths;
     }
 
     [Fact]

--- a/tests/HttpClientInterception.Tests/Bundles/BundleExtensionsTests.cs
+++ b/tests/HttpClientInterception.Tests/Bundles/BundleExtensionsTests.cs
@@ -331,9 +331,9 @@ public static class BundleExtensionsTests
         string path = "foo.bar";
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => ((HttpClientInterceptorOptions)null).RegisterBundle(path), "options");
-        Should.Throw<ArgumentNullException>(() => options.RegisterBundle(null), "path");
-        Should.Throw<ArgumentNullException>(() => options.RegisterBundle(path, null), "templateValues");
+        Should.Throw<ArgumentNullException>(() => ((HttpClientInterceptorOptions)null).RegisterBundle(path)).ParamName.ShouldBe("options");
+        Should.Throw<ArgumentNullException>(() => options.RegisterBundle(null)).ParamName.ShouldBe("path");
+        Should.Throw<ArgumentNullException>(() => options.RegisterBundle(path, null)).ParamName.ShouldBe("templateValues");
     }
 
     [Fact]
@@ -344,8 +344,8 @@ public static class BundleExtensionsTests
         string path = "foo.bar";
 
         // Act and Assert
-        await Should.ThrowAsync<ArgumentNullException>(() => ((HttpClientInterceptorOptions)null).RegisterBundleAsync(path), "options");
-        await Should.ThrowAsync<ArgumentNullException>(() => options.RegisterBundleAsync(null), "path");
+        (await Should.ThrowAsync<ArgumentNullException>(() => ((HttpClientInterceptorOptions)null).RegisterBundleAsync(path))).ParamName.ShouldBe("options");
+        (await Should.ThrowAsync<ArgumentNullException>(() => options.RegisterBundleAsync(null))).ParamName.ShouldBe("path");
     }
 
     [Fact]

--- a/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsExtensionsTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsExtensionsTests.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Just Eat, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Text.Json.Serialization;
+
 namespace JustEat.HttpClientInterception;
 
-public static class HttpClientInterceptorOptionsExtensionsTests
+public static partial class HttpClientInterceptorOptionsExtensionsTests
 {
     [Fact]
-    public static async Task RegisterGetJson_For_With_Defaults_Registers_Interception()
+    public static async Task RegisterGetJson_With_Defaults_Registers_Interception()
     {
         // Arrange
         string requestUri = "https://google.com/";
@@ -28,13 +30,48 @@ public static class HttpClientInterceptorOptionsExtensionsTests
         HttpClientInterceptorOptions options = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.RegisterGetJson("https://google.com", new { }), "options");
+        Should.Throw<ArgumentNullException>(() => options.RegisterGetJson("https://google.com", new { })).ParamName.ShouldBe("options");
 
         // Arrange
         options = new HttpClientInterceptorOptions();
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.RegisterGetJson("https://google.com", null), "content");
+        Should.Throw<ArgumentNullException>(() => options.RegisterGetJson("https://google.com", null)).ParamName.ShouldBe("content");
+    }
+
+    [Fact]
+    public static async Task RegisterGetFromJson_With_Defaults_Registers_Interception()
+    {
+        // Arrange
+        string requestUri = "https://google.com/";
+        string[] expected = ["foo", "bar"];
+        var jsonTypeInfo = CustomJsonSerializerContext.Default.StringArray;
+
+        var options = new HttpClientInterceptorOptions().RegisterGetFromJson(requestUri, expected, jsonTypeInfo);
+
+        // Act
+        string[] actual = await HttpAssert.GetAsync<string[]>(options, requestUri);
+
+        // Assert
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public static void RegisterGetFromJson_Validates_Parameters_For_Null()
+    {
+        // Arrange
+        HttpClientInterceptorOptions options = null;
+        var content = new CustomJsonObject();
+        var jsonTypeInfo = CustomJsonSerializerContext.Default.CustomJsonObject;
+
+        // Act and Assert
+        Should.Throw<ArgumentNullException>(() => options.RegisterGetFromJson("https://google.com", content, jsonTypeInfo)).ParamName.ShouldBe("options");
+
+        // Arrange
+        options = new HttpClientInterceptorOptions();
+
+        // Act and Assert
+        Should.Throw<ArgumentNullException>(() => options.RegisterGetFromJson("https://google.com", content, null)).ParamName.ShouldBe("jsonTypeInfo");
     }
 
     [Fact]
@@ -94,7 +131,7 @@ public static class HttpClientInterceptorOptionsExtensionsTests
         HttpClientInterceptorOptions options = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.RegisterGet("https://google.com", string.Empty), "options");
+        Should.Throw<ArgumentNullException>(() => options.RegisterGet("https://google.com", string.Empty)).ParamName.ShouldBe("options");
     }
 
     [Fact]
@@ -104,7 +141,7 @@ public static class HttpClientInterceptorOptionsExtensionsTests
         HttpClientInterceptorOptions options = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.DeregisterGet("https://google.com"), "options");
+        Should.Throw<ArgumentNullException>(() => options.DeregisterGet("https://google.com")).ParamName.ShouldBe("options");
     }
 
     [Fact]
@@ -118,7 +155,7 @@ public static class HttpClientInterceptorOptionsExtensionsTests
         IEnumerable<KeyValuePair<string, string>> headers = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory: Array.Empty<byte>, responseHeaders: headers), "options");
+        Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory: Array.Empty<byte>, responseHeaders: headers)).ParamName.ShouldBe("options");
     }
 
     [Fact]
@@ -131,7 +168,7 @@ public static class HttpClientInterceptorOptionsExtensionsTests
         HttpClientInterceptorOptions options = null;
         IEnumerable<KeyValuePair<string, string>> headers = null;
 
-        Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream: () => Stream.Null, responseHeaders: headers), "options");
+        Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream: () => Stream.Null, responseHeaders: headers)).ParamName.ShouldBe("options");
     }
 
     [Fact]
@@ -143,7 +180,7 @@ public static class HttpClientInterceptorOptionsExtensionsTests
         HttpClientInterceptorOptions options = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.CreateHttpClient(baseAddress), "options");
+        Should.Throw<ArgumentNullException>(() => options.CreateHttpClient(baseAddress)).ParamName.ShouldBe("options");
     }
 
     [Fact]
@@ -155,7 +192,7 @@ public static class HttpClientInterceptorOptionsExtensionsTests
         HttpClientInterceptorOptions options = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.Register(new List<HttpRequestInterceptionBuilder>()), "options");
+        Should.Throw<ArgumentNullException>(() => options.Register(new List<HttpRequestInterceptionBuilder>())).ParamName.ShouldBe("options");
     }
 
     [Fact]
@@ -168,7 +205,7 @@ public static class HttpClientInterceptorOptionsExtensionsTests
         IEnumerable<HttpRequestInterceptionBuilder> collection = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.Register(collection), "collection");
+        Should.Throw<ArgumentNullException>(() => options.Register(collection)).ParamName.ShouldBe("collection");
     }
 
     [Fact]
@@ -212,7 +249,7 @@ public static class HttpClientInterceptorOptionsExtensionsTests
         HttpClientInterceptorOptions options = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.Register([]), "options");
+        Should.Throw<ArgumentNullException>(() => options.Register([])).ParamName.ShouldBe("options");
     }
 
     [Fact]
@@ -225,7 +262,7 @@ public static class HttpClientInterceptorOptionsExtensionsTests
         HttpRequestInterceptionBuilder[] collection = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.Register(collection), "collection");
+        Should.Throw<ArgumentNullException>(() => options.Register(collection)).ParamName.ShouldBe("collection");
     }
 
     [Fact]
@@ -267,7 +304,7 @@ public static class HttpClientInterceptorOptionsExtensionsTests
         HttpClientInterceptorOptions options = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(options.ThrowsOnMissingRegistration, "options");
+        Should.Throw<ArgumentNullException>(options.ThrowsOnMissingRegistration).ParamName.ShouldBe("options");
     }
 
     [Fact]
@@ -296,5 +333,15 @@ public static class HttpClientInterceptorOptionsExtensionsTests
         public int Number { get; set; }
 
         public string Text { get; set; }
+    }
+
+    private sealed class CustomJsonObject
+    {
+    }
+
+    [JsonSerializable(typeof(string[]))]
+    [JsonSerializable(typeof(CustomJsonObject))]
+    private sealed partial class CustomJsonSerializerContext : JsonSerializerContext
+    {
     }
 }

--- a/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpClientInterceptorOptionsTests.cs
@@ -503,7 +503,7 @@ public static class HttpClientInterceptorOptionsTests
         Uri uri = new Uri("https://www.just-eat.co.uk");
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.Deregister(method, uri), "method");
+        Should.Throw<ArgumentNullException>(() => options.Deregister(method, uri)).ParamName.ShouldBe("method");
     }
 
     [Fact]
@@ -516,7 +516,7 @@ public static class HttpClientInterceptorOptionsTests
         Uri uri = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.Deregister(method, uri), "uri");
+        Should.Throw<ArgumentNullException>(() => options.Deregister(method, uri)).ParamName.ShouldBe("uri");
     }
 
     [Fact]
@@ -528,7 +528,7 @@ public static class HttpClientInterceptorOptionsTests
         HttpRequestInterceptionBuilder builder = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.Deregister(builder), "builder");
+        Should.Throw<ArgumentNullException>(() => options.Deregister(builder)).ParamName.ShouldBe("builder");
     }
 
     [Fact]
@@ -541,7 +541,7 @@ public static class HttpClientInterceptorOptionsTests
         Uri uri = new Uri("https://www.just-eat.co.uk");
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory: EmptyContent), "method");
+        Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory: EmptyContent)).ParamName.ShouldBe("method");
     }
 
     [Fact]
@@ -554,7 +554,7 @@ public static class HttpClientInterceptorOptionsTests
         var uri = new Uri("https://www.just-eat.co.uk");
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream: EmptyStream), "method");
+        Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream: EmptyStream)).ParamName.ShouldBe("method");
     }
 
     [Fact]
@@ -567,7 +567,7 @@ public static class HttpClientInterceptorOptionsTests
         Uri uri = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory: EmptyContent), "uri");
+        Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory: EmptyContent)).ParamName.ShouldBe("uri");
     }
 
     [Fact]
@@ -580,7 +580,7 @@ public static class HttpClientInterceptorOptionsTests
         Uri uri = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream: EmptyStream), "uri");
+        Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream: EmptyStream)).ParamName.ShouldBe("uri");
     }
 
     [Fact]
@@ -594,7 +594,7 @@ public static class HttpClientInterceptorOptionsTests
         Func<byte[]> contentFactory = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory), "contentFactory");
+        Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory)).ParamName.ShouldBe("contentFactory");
     }
 
     [Fact]
@@ -608,7 +608,7 @@ public static class HttpClientInterceptorOptionsTests
         Func<Task<byte[]>> contentFactory = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory), "contentFactory");
+        Should.Throw<ArgumentNullException>(() => options.RegisterByteArray(method, uri, contentFactory)).ParamName.ShouldBe("contentFactory");
     }
 
     [Fact]
@@ -622,7 +622,7 @@ public static class HttpClientInterceptorOptionsTests
         Func<Stream> contentStream = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream), "contentStream");
+        Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream)).ParamName.ShouldBe("contentStream");
     }
 
     [Fact]
@@ -636,7 +636,7 @@ public static class HttpClientInterceptorOptionsTests
         Func<Task<Stream>> contentStream = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream), "contentStream");
+        Should.Throw<ArgumentNullException>(() => options.RegisterStream(method, uri, contentStream)).ParamName.ShouldBe("contentStream");
     }
 
     [Fact]
@@ -647,7 +647,7 @@ public static class HttpClientInterceptorOptionsTests
         HttpRequestMessage request = null;
 
         // Act and Assert
-        await Should.ThrowAsync<ArgumentNullException>(() => options.GetResponseAsync(request), "request");
+        (await Should.ThrowAsync<ArgumentNullException>(() => options.GetResponseAsync(request))).ParamName.ShouldBe("request");
     }
 
     [Fact]
@@ -658,7 +658,7 @@ public static class HttpClientInterceptorOptionsTests
         HttpRequestInterceptionBuilder builder = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => options.Register(builder), "builder");
+        Should.Throw<ArgumentNullException>(() => options.Register(builder)).ParamName.ShouldBe("builder");
     }
 
     [Fact]

--- a/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
+++ b/tests/HttpClientInterception.Tests/HttpRequestInterceptionBuilderTests.cs
@@ -3,11 +3,12 @@
 
 using System.Net;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json.Linq;
 
 namespace JustEat.HttpClientInterception;
 
-public static class HttpRequestInterceptionBuilderTests
+public static partial class HttpRequestInterceptionBuilderTests
 {
     [Fact]
     public static async Task Register_For_Builder_With_All_Defaults_Registers_Interception()
@@ -39,6 +40,27 @@ public static class HttpRequestInterceptionBuilderTests
             .ForGet()
             .ForUrl(requestUri)
             .WithJsonContent(expected);
+
+        var options = new HttpClientInterceptorOptions().Register(builder);
+
+        // Act
+        var actual = await HttpAssert.GetAsync<string[]>(options, requestUri);
+
+        // Assert
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public static async Task Register_For_Builder_With_Json_Source_Generator_Defaults_Registers_Interception()
+    {
+        // Arrange
+        var requestUri = "https://google.com/";
+        var expected = new[] { "foo", "bar" };
+
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForGet()
+            .ForUrl(requestUri)
+            .WithJsonContent(expected, TestJsonSerializerContext.Default.StringArray);
 
         var options = new HttpClientInterceptorOptions().Register(builder);
 
@@ -672,9 +694,7 @@ public static class HttpRequestInterceptionBuilderTests
             request.Method.ShouldBe(HttpMethod.Post);
             request.RequestUri.ShouldBe(requestUri);
 
-#pragma warning disable xUnit1031
             string json = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-#pragma warning restore xUnit1031
 
             var body = JObject.Parse(json);
 
@@ -785,7 +805,7 @@ public static class HttpRequestInterceptionBuilderTests
     public static void WithContent_Validates_Parameters()
     {
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).WithContent((string)null), "builder");
+        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).WithContent((string)null)).ParamName.ShouldBe("builder");
     }
 
     [Fact]
@@ -796,8 +816,8 @@ public static class HttpRequestInterceptionBuilderTests
         IEnumerable<KeyValuePair<string, string>> parameters = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).WithFormContent(parameters), "builder");
-        Should.Throw<ArgumentNullException>(() => builder.WithFormContent(parameters), "parameters");
+        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).WithFormContent(parameters)).ParamName.ShouldBe("builder");
+        Should.Throw<ArgumentNullException>(() => builder.WithFormContent(parameters)).ParamName.ShouldBe("parameters");
     }
 
     [Fact]
@@ -831,10 +851,14 @@ public static class HttpRequestInterceptionBuilderTests
         // Arrange
         var builder = new HttpRequestInterceptionBuilder();
         object content = null;
+        var typedContent = new CustomObject();
+        var jsonTypeInfo = TestJsonSerializerContext.Default.CustomObject;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).WithJsonContent(content), "builder");
-        Should.Throw<ArgumentNullException>(() => builder.WithJsonContent(content), "content");
+        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).WithJsonContent(content)).ParamName.ShouldBe("builder");
+        Should.Throw<ArgumentNullException>(() => builder.WithJsonContent(content)).ParamName.ShouldBe("content");
+        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).WithJsonContent(typedContent, jsonTypeInfo)).ParamName.ShouldBe("builder");
+        Should.Throw<ArgumentNullException>(() => builder.WithJsonContent(typedContent, null)).ParamName.ShouldBe("jsonTypeInfo");
     }
 
     [Fact]
@@ -845,8 +869,8 @@ public static class HttpRequestInterceptionBuilderTests
         object content = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).WithSystemTextJsonContent(content), "builder");
-        Should.Throw<ArgumentNullException>(() => builder.WithSystemTextJsonContent(content), "content");
+        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).WithSystemTextJsonContent(content)).ParamName.ShouldBe("builder");
+        Should.Throw<ArgumentNullException>(() => builder.WithSystemTextJsonContent(content)).ParamName.ShouldBe("content");
     }
 
     [Fact]
@@ -856,49 +880,49 @@ public static class HttpRequestInterceptionBuilderTests
         string uriString = "https://google.com/";
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForUrl(uriString), "builder");
+        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForUrl(uriString)).ParamName.ShouldBe("builder");
     }
 
     [Fact]
     public static void ForDelete_Validates_Parameters()
     {
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForDelete(), "builder");
+        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForDelete()).ParamName.ShouldBe("builder");
     }
 
     [Fact]
     public static void ForGet_Validates_Parameters()
     {
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForGet(), "builder");
+        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForGet()).ParamName.ShouldBe("builder");
     }
 
     [Fact]
     public static void ForPost_Validates_Parameters()
     {
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForPost(), "builder");
+        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForPost()).ParamName.ShouldBe("builder");
     }
 
     [Fact]
     public static void ForPut_Validates_Parameters()
     {
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForPut(), "builder");
+        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForPut()).ParamName.ShouldBe("builder");
     }
 
     [Fact]
     public static void ForHttp_Validates_Parameters()
     {
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForHttp(), "builder");
+        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForHttp()).ParamName.ShouldBe("builder");
     }
 
     [Fact]
     public static void ForHttps_Validates_Parameters()
     {
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForHttps(), "builder");
+        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForHttps()).ParamName.ShouldBe("builder");
     }
 
     [Fact]
@@ -908,7 +932,7 @@ public static class HttpRequestInterceptionBuilderTests
         HttpRequestInterceptionBuilder builder = new HttpRequestInterceptionBuilder();
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => builder.ForMethod(null), "method");
+        Should.Throw<ArgumentNullException>(() => builder.ForMethod(null)).ParamName.ShouldBe("method");
     }
 
     [Fact]
@@ -919,7 +943,7 @@ public static class HttpRequestInterceptionBuilderTests
         UriBuilder uriBuilder = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => builder.ForUri(uriBuilder), "uriBuilder");
+        Should.Throw<ArgumentNullException>(() => builder.ForUri(uriBuilder)).ParamName.ShouldBe("uriBuilder");
     }
 
     [Fact]
@@ -1244,7 +1268,7 @@ public static class HttpRequestInterceptionBuilderTests
         var builder = new HttpRequestInterceptionBuilder();
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => builder.RegisterWith(null), "options");
+        Should.Throw<ArgumentNullException>(() => builder.RegisterWith(null)).ParamName.ShouldBe("options");
     }
 
     [Fact]
@@ -1639,11 +1663,11 @@ public static class HttpRequestInterceptionBuilderTests
         var values = Array.Empty<string>();
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(null, string.Empty), "name");
-        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(null, values), "name");
-        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(null, (IEnumerable<string>)values), "name");
-        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(name, (string[])null), "values");
-        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(name, (IEnumerable<string>)null), "values");
+        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(null, string.Empty)).ParamName.ShouldBe("name");
+        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(null, values)).ParamName.ShouldBe("name");
+        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(null, (IEnumerable<string>)values)).ParamName.ShouldBe("name");
+        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(name, (string[])null)).ParamName.ShouldBe("values");
+        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeader(name, (IEnumerable<string>)null)).ParamName.ShouldBe("values");
     }
 
     [Fact]
@@ -1656,9 +1680,9 @@ public static class HttpRequestInterceptionBuilderTests
         Func<IEnumerable<KeyValuePair<string, ICollection<string>>>> headerFactory = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeaders(headersOfString), "headers");
-        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeaders(headersOfStrings), "headers");
-        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeaders(headerFactory), "headerFactory");
+        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeaders(headersOfString)).ParamName.ShouldBe("headers");
+        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeaders(headersOfStrings)).ParamName.ShouldBe("headers");
+        Should.Throw<ArgumentNullException>(() => builder.ForRequestHeaders(headerFactory)).ParamName.ShouldBe("headerFactory");
     }
 
     [Fact]
@@ -1670,11 +1694,11 @@ public static class HttpRequestInterceptionBuilderTests
         var values = Array.Empty<string>();
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(null, string.Empty), "name");
-        Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(null, values), "name");
-        Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(null, (IEnumerable<string>)values), "name");
-        Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(name, (string[])null), "values");
-        Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(name, (IEnumerable<string>)null), "values");
+        Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(null, string.Empty)).ParamName.ShouldBe("name");
+        Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(null, values)).ParamName.ShouldBe("name");
+        Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(null, (IEnumerable<string>)values)).ParamName.ShouldBe("name");
+        Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(name, (string[])null)).ParamName.ShouldBe("values");
+        Should.Throw<ArgumentNullException>(() => builder.WithContentHeader(name, (IEnumerable<string>)null)).ParamName.ShouldBe("values");
     }
 
     [Fact]
@@ -1687,9 +1711,9 @@ public static class HttpRequestInterceptionBuilderTests
         Func<IEnumerable<KeyValuePair<string, ICollection<string>>>> headerFactory = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => builder.WithContentHeaders(headers), "headers");
-        Should.Throw<ArgumentNullException>(() => builder.WithContentHeaders(headerValues), "headers");
-        Should.Throw<ArgumentNullException>(() => builder.WithContentHeaders(headerFactory), "headerFactory");
+        Should.Throw<ArgumentNullException>(() => builder.WithContentHeaders(headers)).ParamName.ShouldBe("headers");
+        Should.Throw<ArgumentNullException>(() => builder.WithContentHeaders(headerValues)).ParamName.ShouldBe("headers");
+        Should.Throw<ArgumentNullException>(() => builder.WithContentHeaders(headerFactory)).ParamName.ShouldBe("headerFactory");
     }
 
     [Fact]
@@ -1701,11 +1725,11 @@ public static class HttpRequestInterceptionBuilderTests
         var values = Array.Empty<string>();
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(null, string.Empty), "name");
-        Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(null, values), "name");
-        Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(null, (IEnumerable<string>)values), "name");
-        Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(name, (string[])null), "values");
-        Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(name, (IEnumerable<string>)null), "values");
+        Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(null, string.Empty)).ParamName.ShouldBe("name");
+        Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(null, values)).ParamName.ShouldBe("name");
+        Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(null, (IEnumerable<string>)values)).ParamName.ShouldBe("name");
+        Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(name, (string[])null)).ParamName.ShouldBe("values");
+        Should.Throw<ArgumentNullException>(() => builder.WithResponseHeader(name, (IEnumerable<string>)null)).ParamName.ShouldBe("values");
     }
 
     [Fact]
@@ -1717,8 +1741,8 @@ public static class HttpRequestInterceptionBuilderTests
         Func<IEnumerable<KeyValuePair<string, ICollection<string>>>> headerFactory = null;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => builder.WithResponseHeaders(headers), "headers");
-        Should.Throw<ArgumentNullException>(() => builder.WithResponseHeaders(headerFactory), "headerFactory");
+        Should.Throw<ArgumentNullException>(() => builder.WithResponseHeaders(headers)).ParamName.ShouldBe("headers");
+        Should.Throw<ArgumentNullException>(() => builder.WithResponseHeaders(headerFactory)).ParamName.ShouldBe("headerFactory");
     }
 
     [Fact]
@@ -1729,8 +1753,8 @@ public static class HttpRequestInterceptionBuilderTests
         var parameters = new Dictionary<string, string>();
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForFormContent(parameters), "builder");
-        Should.Throw<ArgumentNullException>(() => builder.ForFormContent(null), "parameters");
+        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForFormContent(parameters)).ParamName.ShouldBe("builder");
+        Should.Throw<ArgumentNullException>(() => builder.ForFormContent(null)).ParamName.ShouldBe("parameters");
     }
 
     [Fact]
@@ -1740,7 +1764,7 @@ public static class HttpRequestInterceptionBuilderTests
         static bool Predicate(HttpContent content) => false;
 
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForContent(Predicate), "builder");
+        Should.Throw<ArgumentNullException>(() => ((HttpRequestInterceptionBuilder)null).ForContent(Predicate)).ParamName.ShouldBe("builder");
     }
 
     [Fact]
@@ -2147,14 +2171,12 @@ public static class HttpRequestInterceptionBuilderTests
     public static async Task Builder_For_Posted_Json_To_Match_Intercepts_Request()
     {
         // Arrange
-#pragma warning disable xUnit1031
         var builder = new HttpRequestInterceptionBuilder()
             .ForUrl("https://test.local/post")
             .ForPost()
             .ForContent((content) => content.ReadAsStringAsync().Result == @"{""message"":""Hello, Alice""}")
             .Responds()
             .WithJsonContent(new { message = "Hi Bob!" });
-#pragma warning restore xUnit1031
 
         var options = new HttpClientInterceptorOptions()
             .ThrowsOnMissingRegistration()
@@ -2227,7 +2249,7 @@ public static class HttpRequestInterceptionBuilderTests
                 .WithStatus(HttpStatusCode.OK);
 
         // Act & Assert
-        Should.Throw<ArgumentNullException>(InterceptionBuilder);
+        Should.Throw<ArgumentNullException>(InterceptionBuilder).ParamName.ShouldBe("predicates");
     }
 
     [Fact]
@@ -2263,7 +2285,7 @@ public static class HttpRequestInterceptionBuilderTests
                 .WithStatus(HttpStatusCode.OK);
 
         // Act & Assert
-        Should.Throw<ArgumentNullException>(InterceptionBuilder);
+        Should.Throw<ArgumentNullException>(InterceptionBuilder).ParamName.ShouldBe("predicates");
     }
 
     [Fact]
@@ -2430,5 +2452,11 @@ public static class HttpRequestInterceptionBuilderTests
         public int Number { get; set; }
 
         public string Text { get; set; }
+    }
+
+    [JsonSerializable(typeof(string[]))]
+    [JsonSerializable(typeof(CustomObject))]
+    private sealed partial class TestJsonSerializerContext : JsonSerializerContext
+    {
     }
 }

--- a/tests/HttpClientInterception.Tests/InterceptingHttpMessageHandlerTests.cs
+++ b/tests/HttpClientInterception.Tests/InterceptingHttpMessageHandlerTests.cs
@@ -14,8 +14,8 @@ public static class InterceptingHttpMessageHandlerTests
     public static void Constructor_Throws_If_Options_Is_Null()
     {
         // Act and Assert
-        Should.Throw<ArgumentNullException>(() => new InterceptingHttpMessageHandler(null), "options");
-        Should.Throw<ArgumentNullException>(() => new InterceptingHttpMessageHandler(null, Substitute.For<HttpMessageHandler>()), "options");
+        Should.Throw<ArgumentNullException>(() => new InterceptingHttpMessageHandler(null)).ParamName.ShouldBe("options");
+        Should.Throw<ArgumentNullException>(() => new InterceptingHttpMessageHandler(null, Substitute.For<HttpMessageHandler>())).ParamName.ShouldBe("options");
     }
 
     [Fact]

--- a/tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj
+++ b/tests/HttpClientInterception.Tests/JustEat.HttpClientInterception.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Tests for JustEat.HttpClientInterception</Description>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>$(NoWarn);CA1303;CA1600;CA1707;CA1812;CA1861;CA2000;CA2007;SA1600</NoWarn>
+    <NoWarn>$(NoWarn);CA1303;CA1600;CA1707;CA1812;CA1861;CA2000;CA2007;SA1600;SA1601</NoWarn>
     <RootNamespace>JustEat.HttpClientInterception</RootNamespace>
     <Summary>Tests for JustEat.HttpClientInterception</Summary>
     <TargetFrameworks>net8.0</TargetFrameworks>


### PR DESCRIPTION
- Add support for native AoT for `net6.0` and `net7.0`.
- Use `JsonSerializer.SerializeToUtf8Bytes()` where possible.
- Fix `ArgumentException.ParamName` not being asserted on.
- Fix benchmarks no longer running due to use of Artifacts Output and an incorrectly defined POCO property.
- Fix unit analyser warning by using `TheoryData<T>`.
- Add unit tests for missing coverage.
- Simplify some tests.
- Update benchmarks in README.
