### PR TITLE
Add dedicated package README

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,9 @@
+{
+  "MD013": false,
+  "MD033": {
+    "allowed_elements": [
+      "a",
+      "sup"
+    ]
+  }
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/justeattakeaway/httpclient-interception</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>package-readme.md</PackageReadmeFile>
     <PackageReleaseNotes>See $(PackageProjectUrl)/releases for details.</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>http,httpclient,interception,testing</PackageTags>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This design means that no HTTP server needs to be hosted to proxy traffic to/fro
 
 To install the library from [NuGet](https://www.nuget.org/packages/JustEat.HttpClientInterception/ "JustEat.HttpClientInterception on NuGet.org") using the .NET SDK run:
 
-```
+```text
 dotnet add package JustEat.HttpClientInterception
 ```
 
@@ -33,6 +33,8 @@ dotnet add package JustEat.HttpClientInterception
 ##### Fluent API
 
 Below is a minimal example of intercepting an HTTP GET request to an API for a JSON resource to return a custom response using the fluent API:
+
+<!-- markdownlint-disable MD031 -->
 
 <!-- snippet: minimal-example -->
 <a id='snippet-minimal-example'></a>
@@ -244,7 +246,7 @@ Further examples of using the library can be found by following the links below:
 
 Generated with the [Benchmarks project](https://github.com/justeattakeaway/httpclient-interception/blob/main/tests/HttpClientInterception.Benchmarks/InterceptionBenchmarks.cs "JustEat.HttpClientInterception benchmark code") using [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet "BenchmarkDotNet on GitHub.com") using commit [ef93cb5](https://github.com/justeattakeaway/httpclient-interception/commit/ef93cb5a54b518fe488de63be962ddf15644ef42 "Benchmark commit") on 04/02/2024.
 
-```
+```text
 
 BenchmarkDotNet v0.13.12, Windows 11 (10.0.22621.3007/22H2/2022Update/SunValley2)
 12th Gen Intel Core i7-1270P, 1 CPU, 16 logical and 12 physical cores
@@ -252,7 +254,7 @@ BenchmarkDotNet v0.13.12, Windows 11 (10.0.22621.3007/22H2/2022Update/SunValley2
   [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
   Job-IMNGZO : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
 
-Arguments=/p:UseArtifactsOutput=false  
+Arguments=/p:UseArtifactsOutput=false
 
 ```
 | Method                       | Mean       | Error     | StdDev     | Median     | Gen0   | Allocated |
@@ -264,7 +266,6 @@ Arguments=/p:UseArtifactsOutput=false
 | GetJsonObjectSourceGenerator |   2.345 μs | 0.0421 μs |  0.1102 μs |   2.311 μs | 0.3281 |   3.05 KB |
 | GetJsonObjectWithRefit       |   5.169 μs | 0.1025 μs |  0.2117 μs |   5.120 μs | 0.6714 |   6.35 KB |
 | GetStream                    | 209.607 μs | 4.5593 μs | 13.3717 μs | 210.077 μs | 0.2441 |   3.16 KB |
-
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This library provides functionality for intercepting HTTP requests made using th
 
 The primary use-case is for providing stub responses for use in tests for applications, such as an ASP.NET Core application, to drive your functional test scenarios.
 
-The library is based around an implementation of [`DelegatingHandler`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.delegatinghandler "DelegatingHandler documentation"), which can either be used directly as an implementation of `HttpMessageHandler`, or can be provided to instances of `HttpClient`. This also allows it to be registered via Dependency Injection to make it available for use in code under test without the application itself requiring any references to `JustEat.HttpClientInterception` or any custom abstractions of `HttpClient`.
+The library is based around an implementation of [`DelegatingHandler`](https://learn.microsoft.com/dotnet/api/system.net.http.delegatinghandler "DelegatingHandler documentation"), which can either be used directly as an implementation of `HttpMessageHandler`, or can be provided to instances of `HttpClient`. This also allows it to be registered via Dependency Injection to make it available for use in code under test without the application itself requiring any references to `JustEat.HttpClientInterception` or any custom abstractions of `HttpClient`.
 
 This design means that no HTTP server needs to be hosted to proxy traffic to/from, so does not consume any additional system resources, such as needing to bind a port for HTTP traffic, making it lightweight to use.
 
@@ -150,7 +150,7 @@ await Assert.ThrowsAsync<HttpRequestException>(
 
 #### Registering Request Interception When Using IHttpClientFactory
 
-If you are using [`IHttpClientFactory`](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests "Use IHttpClientFactory to implement resilient HTTP requests") to register `HttpClient` for Dependency Injection in a .NET Core 3.1 application (or later), you can implement a custom [`IHttpMessageHandlerBuilderFilter`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.http.ihttpmessagehandlerbuilderfilter "IHttpMessageHandlerBuilderFilter Interface") to register during test setup, which makes an instance of `HttpClientInterceptorOptions` available to inject an HTTP handler.
+If you are using [`IHttpClientFactory`](https://learn.microsoft.com/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests "Use IHttpClientFactory to implement resilient HTTP requests") to register `HttpClient` for Dependency Injection in a .NET application (or later), you can implement a custom [`IHttpMessageHandlerBuilderFilter`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.http.ihttpmessagehandlerbuilderfilter "IHttpMessageHandlerBuilderFilter Interface") to register during test setup, which makes an instance of `HttpClientInterceptorOptions` available to inject an HTTP handler.
 
 A working example of this approach can be found in the [sample application](https://github.com/justeattakeaway/httpclient-interception/blob/main/samples/README.md "Sample application that uses JustEat.HttpClientInterception").
 

--- a/package-readme.md
+++ b/package-readme.md
@@ -12,7 +12,7 @@ This library provides functionality for intercepting HTTP requests made using th
 
 The primary use-case is for providing stub responses for use in tests for applications, such as an ASP.NET Core application, to drive your functional test scenarios.
 
-The library is based around an implementation of [`DelegatingHandler`](https://docs.microsoft.com/dotnet/api/system.net.http.delegatinghandler "DelegatingHandler documentation"), which can either be used directly as an implementation of `HttpMessageHandler`, or can be provided to instances of `HttpClient`. This also allows it to be registered via Dependency Injection to make it available for use in code under test without the application itself requiring any references to `JustEat.HttpClientInterception` or any custom abstractions of `HttpClient`.
+The library is based around an implementation of [`DelegatingHandler`](https://learn.microsoft.com/dotnet/api/system.net.http.delegatinghandler "DelegatingHandler documentation"), which can either be used directly as an implementation of `HttpMessageHandler`, or can be provided to instances of `HttpClient`. This also allows it to be registered via Dependency Injection to make it available for use in code under test without the application itself requiring any references to `JustEat.HttpClientInterception` or any custom abstractions of `HttpClient`.
 
 This design means that no HTTP server needs to be hosted to proxy traffic to/from, so does not consume any additional system resources, such as needing to bind a port for HTTP traffic, making it lightweight to use.
 

--- a/package-readme.md
+++ b/package-readme.md
@@ -1,0 +1,25 @@
+# HttpClient Interception
+
+A .NET Standard library for intercepting server-side HTTP dependencies.
+
+[![NuGet version](https://buildstats.info/nuget/JustEat.HttpClientInterception?includePreReleases=false)](https://www.nuget.org/packages/JustEat.HttpClientInterception/)
+[![Build status](https://github.com/justeattakeaway/httpclient-interception/workflows/build/badge.svg?branch=main&event=push)](https://github.com/justeattakeaway/httpclient-interception/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush)
+[![codecov](https://codecov.io/gh/justeattakeaway/httpclient-interception/branch/main/graph/badge.svg)](https://codecov.io/gh/justeattakeaway/httpclient-interception)
+
+## Introduction
+
+This library provides functionality for intercepting HTTP requests made using the `HttpClient` class in code targeting .NET Standard 2.0 (and later), and .NET Framework 4.7.2.
+
+The primary use-case is for providing stub responses for use in tests for applications, such as an ASP.NET Core application, to drive your functional test scenarios.
+
+The library is based around an implementation of [`DelegatingHandler`](https://docs.microsoft.com/dotnet/api/system.net.http.delegatinghandler "DelegatingHandler documentation"), which can either be used directly as an implementation of `HttpMessageHandler`, or can be provided to instances of `HttpClient`. This also allows it to be registered via Dependency Injection to make it available for use in code under test without the application itself requiring any references to `JustEat.HttpClientInterception` or any custom abstractions of `HttpClient`.
+
+This design means that no HTTP server needs to be hosted to proxy traffic to/from, so does not consume any additional system resources, such as needing to bind a port for HTTP traffic, making it lightweight to use.
+
+## Feedback
+
+Any feedback or issues for this library can be added to the issues in [GitHub](https://github.com/justeattakeaway/httpclient-interception/issues "This package's issues on GitHub.com").
+
+## License
+
+This package is licensed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.html "The Apache 2.0 license") license.


### PR DESCRIPTION
NuGet.org's content security policy and reduced Markdown rendering support mean that the [project README doesn't render well](https://www.nuget.org/packages/JustEat.HttpClientInterception/#readme-body-tab) in the NuGet gallery. Instead, add a dedicated package README with pared-back information that will render better.

It's not worth publishing a new release _just_ to fix the README rendering, but it'll be improved next time there is a new version published.

Also:

- Fix or suppress a number of Markdownlint warnings in the README.
- Remove `en-US`-specific documentation links.
- Update Microsoft documentation subdomain.
- Update reference to .NET Core.
