### PR TITLE
Fix package version overrides

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,4 @@ updates:
   - dependency-name: Microsoft.AspNetCore.WebUtilities
   - dependency-name: Newtonsoft.Json
   - dependency-name: System.Net.Http
+  - dependency-name: System.Text.Json

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,12 +22,6 @@
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(AssemblyName)' == 'JustEat.HttpClientInterception' and '$(TargetFramework)' == 'net6.0' ">
-    <PackageVersion Update="System.Text.Json" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(AssemblyName)' != 'JustEat.HttpClientInterception' ">
-    <PackageVersion Update="System.Text.Json" Version="8.0.0" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />

--- a/src/HttpClientInterception/JustEat.HttpClientInterception.csproj
+++ b/src/HttpClientInterception/JustEat.HttpClientInterception.csproj
@@ -19,6 +19,12 @@
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+    <PackageVersion Update="System.Text.Json" VersionOverride="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
+    <PackageVersion Update="System.Text.Json" VersionOverride="7.0.0" />
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Net.Http" />
   </ItemGroup>
@@ -27,10 +33,6 @@
     <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
-    <EnableAotAnalyzer>true</EnableAotAnalyzer>
-    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <IsAotCompatible>true</IsAotCompatible>
-    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Use VersionOverride and IsTargetFrameworkCompatible for System.Text.Json versions.
- Fix net7.0 target not using the right version of System.Text.Json.
- Simplify AoT properties.
- Ignore dependabot package updates for System.Text.Json.
