### PR TITLE
Fix permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       cancel-in-progress: false
 
     permissions:
-      contents: read
+      contents: write
       issues: write
 
     steps:


### PR DESCRIPTION
[Write access is needed](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#generate-release-notes-content-for-a-release--fine-grained-access-tokens), for some reason, to generate release notes.
