### PR TITLE
Attest artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
       with:
         subject-path: |
-          ./artifacts/publish/JustEat.HttpClientInterception/release*/JustEat.HttpClientInterception.dll
+          ./artifacts/bin/JustEat.HttpClientInterception/release*/JustEat.HttpClientInterception.dll
           ./artifacts/package/release/*
 
     - name: Publish artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     outputs:
-        dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
+      dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
+
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
 
     strategy:
       fail-fast: false
@@ -64,6 +69,17 @@ jobs:
         file: ./artifacts/coverage/coverage.cobertura.xml
         flags: ${{ matrix.os_name }}
         token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Attest artifacts
+      uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
+      if: |
+        runner.os == 'Windows' &&
+        github.event.repository.fork == false &&
+        (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
+      with:
+        subject-path: |
+          ./artifacts/publish/JustEat.HttpClientInterception/release*/JustEat.HttpClientInterception.dll
+          ./artifacts/package/release/*
 
     - name: Publish artifacts
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ typings
 UpgradeLog*.htm
 UpgradeLog*.XML
 PublishProfiles
+*.binlog
 *.coverage
 *.DotSettings
 *.GhostDoc.xml


### PR DESCRIPTION
- Attest the binaries and packages from the build artifacts.
- Ignore binlog files.
