### PR TITLE
Fix content negotiation

### DIFF
--- a/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
+++ b/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs
@@ -472,7 +472,7 @@ public class HttpRequestInterceptionBuilder
 
         if (!_contentHeaders.TryGetValue(name, out var current))
         {
-            _contentHeaders[name] = current = new List<string>();
+            _contentHeaders[name] = current = [];
         }
 
         current.Clear();
@@ -617,7 +617,7 @@ public class HttpRequestInterceptionBuilder
 
         if (!_responseHeaders.TryGetValue(name, out ICollection<string>? current))
         {
-            _responseHeaders[name] = current = new List<string>();
+            _responseHeaders[name] = current = [];
         }
 
         current.Clear();
@@ -955,7 +955,7 @@ public class HttpRequestInterceptionBuilder
 
         if (!_requestHeaders.TryGetValue(name, out ICollection<string>? current))
         {
-            _requestHeaders[name] = current = new List<string>();
+            _requestHeaders[name] = current = [];
         }
 
         current.Clear();
@@ -1108,7 +1108,7 @@ public class HttpRequestInterceptionBuilder
 
                 foreach (var pair in _requestHeaders)
                 {
-                    headers[pair.Key] = pair.Value;
+                    headers[pair.Key] = [.. pair.Value];
                 }
 
                 response.RequestHeaders = headers;
@@ -1127,7 +1127,7 @@ public class HttpRequestInterceptionBuilder
 
                 foreach (var pair in _responseHeaders)
                 {
-                    headers[pair.Key] = pair.Value;
+                    headers[pair.Key] = [.. pair.Value];
                 }
 
                 response.ResponseHeaders = headers;
@@ -1171,7 +1171,7 @@ public class HttpRequestInterceptionBuilder
         }
     }
 
-    private sealed class DynamicDictionary :
+    internal sealed class DynamicDictionary :
         IDictionary<string, ICollection<string>>,
         IEnumerable<KeyValuePair<string, IEnumerable<string>>>
     {


### PR DESCRIPTION
Fix inability to return different responses based on content negotiation via HTTP request headers by including a hash of their names and values in the key for the registration.

------------

As per the test, I found this while doing some work where I needed to intercept responses to the GitHub API. The [Get a pull request](https://docs.github.com/rest/pulls/pulls#get-a-pull-request) has a behaviour where different values for the `Accept` header change the format of the response.

I had the need to get the JSON representation of a pull request and the diff for it in the same operation. This isn't currently possible using the "simple" API as the HTTP request headers aren't taken into account when storing the interception registrations, which created a Last-One-Wins situation meaning you couldn't have a response for the same HTTP method and URL.

While it was possible using the [`For()`](https://github.com/justeattakeaway/httpclient-interception/blob/32d486a5c643292cb7e304009320e6262ada3c3b/src/HttpClientInterception/HttpRequestInterceptionBuilder.cs#L153) overloads, this has the user fall off a cliff in terms of usability and needs them to write all the matching logic themselves.

In addition to the key changes, the collections used for header collections weren't being copied, meaning that the values also got mutated by reference when the user changed the registration. This part could potentially be a breaking behaviour change if someone is mutating a builder post-request expecting the matched values to change, but I don't think that's the behaviour originally intended in the design so is accidental.
