### PR TITLE
Remove dependabot reviewers property

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
   schedule:
     interval: monthly
     timezone: Europe/London
-  reviewers:
-    - "justeattakeaway/httpclient-interception"
 - package-ecosystem: nuget
   directory: "/"
   groups:
@@ -16,8 +14,6 @@ updates:
   schedule:
     interval: monthly
     timezone: Europe/London
-  reviewers:
-    - "justeattakeaway/httpclient-interception"
   open-pull-requests-limit: 99
   ignore:
   - dependency-name: Microsoft.AspNetCore.WebUtilities


### PR DESCRIPTION
Per https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/ this property is being retired in favour of using the codeowners file
